### PR TITLE
Fix podcast page markup and link rendering

### DIFF
--- a/JavaScript/podcast/index.js
+++ b/JavaScript/podcast/index.js
@@ -15,7 +15,6 @@ document.addEventListener("DOMContentLoaded", () => {
     function renderPodcasts() {
         podcastList.innerHTML = podcasts.map(podcast => `
             <a href="${podcast.link}" class="podcast-card">
-            <div class="podcast-card">
                 <div class="podcast-image">
                     <img src="${podcast.image}" alt="${podcast.title}">
                 </div>
@@ -27,14 +26,15 @@ document.addEventListener("DOMContentLoaded", () => {
                         by ${podcast.creator}
                     </div>
                     <div class="podcast-stats">
-                        <span>★ ${podcast.rating}</span> 
+                        <span>★ ${podcast.rating}</span>
                         <span>|
                         <span>${podcast.listeners} listeners</span>
                     </div>
                 </div>
-            </div>
+            </a>
         `).join('');
     }
 
     renderPodcasts();
 });
+

--- a/JavaScript/podcast/tmsa.js
+++ b/JavaScript/podcast/tmsa.js
@@ -2,10 +2,9 @@ document.addEventListener("DOMContentLoaded", () => {
     const podcastList = document.getElementById("podcastapp");
 
     const podcasts = [
-        { title: "เล่าเรื่องเก่ง", creator: "sorasukt", image: "https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/podcast/เล่าเรื่องเก่ง.png", rating: "4.8", listeners: "1.6K", link: "https://podcasts.apple.com/th/podcast/%E0%B9%80%E0%B8%A5-%E0%B8%B2%E0%B9%80%E0%B8%A3-%E0%B8%AD%E0%B8%87%E0%B9%80%E0%B8%81-%E0%B8%87/id1486563415"
-        },
+        { title: "เล่าเรื่องเก่ง", creator: "sorasukt", image: "https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/podcast/เล่าเรื่องเก่ง.png", rating: "4.8", listeners: "1.6K", link: "https://podcasts.apple.com/th/podcast/%E0%B9%80%E0%B8%A5-%E0%B8%B2%E0%B9%80%E0%B8%A3-%E0%B8%AD%E0%B8%87%E0%B9%80%E0%B8%81-%E0%B8%87/id1486563415" },
         { title: "Talking with LITALK", creator: "LITALK Education", image: "https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/podcast/talkingwithlitalk.png", rating: "Coming Soon Show", listeners: "1K", link: "https://podcasts.apple.com/th/podcast/talking-with-litalk/id1786381161"},
-        { title: "ติดกับเรื่องราว", creator: "sorasukt", image: "https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/podcast/tidkab.png", rating: "3.2", listeners: "317", link: "https://podcasts.apple.com/th/podcast/%E0%B8%95-%E0%B8%94%E0%B8%81-%E0%B8%9A%E0%B9%80%E0%B8%A3-%E0%B8%AD%E0%B8%87%E0%B8%A3%E0%B8%B2%E0%B8%A7/id1564119401"},
+        { title: "ติดกับเรื่องราว", creator: "sorasukt", image: "https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/podcast/tidkab.png", rating: "3.2", listeners: "317", link: "https://podcasts.apple.com/th/podcast/%E0%B8%95-%E0%B8%94%E0%B8%81-%E0%B8%9A%E0%B9%80%E0%B8%A3-%E0%B8%AD%E0%B8%87%E0%B8%A3%E0%B8%B2%E0%B8%A7/id1564119401"}
     ];
 
     function isThaiText(text) {
@@ -15,7 +14,6 @@ document.addEventListener("DOMContentLoaded", () => {
     function renderPodcasts() {
         podcastList.innerHTML = podcasts.map(podcast => `
             <a href="${podcast.link}" class="podcast-card">
-            <div class="podcast-card">
                 <div class="podcast-image">
                     <img src="${podcast.image}" alt="${podcast.title}">
                 </div>
@@ -27,14 +25,15 @@ document.addEventListener("DOMContentLoaded", () => {
                         by ${podcast.creator}
                     </div>
                     <div class="podcast-stats">
-                        <span>★ ${podcast.rating}</span> 
+                        <span>★ ${podcast.rating}</span>
                         <span>|
                         <span>${podcast.listeners} listeners</span>
                     </div>
                 </div>
-            </div>
+            </a>
         `).join('');
     }
 
     renderPodcasts();
 });
+

--- a/podcast/index.html
+++ b/podcast/index.html
@@ -2,38 +2,39 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Podcast | STNET Radio</title>
-  <link rel="icon" href="https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/logo/fav.ico" type="image/x-icon">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Podcast | STNET Radio</title>
+    <link rel="icon" href="https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/logo/fav.ico" type="image/x-icon">
     <link rel="stylesheet" href="/CSS/podcast/index.css">
     <link rel="stylesheet" href="/CSS/footer.css">
     <link rel="stylesheet" href="/CSS/brand.css">
-
+</head>
+<body>
     <header>
         <a href="https://stnetradio.com" class="brand">STNET Radio</a>
         <nav>
-          <ul>
-            <li><a href="/">Home</a></li>
-            <li><a href="/plus/">Plus+</a></li>
-            <li><a href="#">Podcast</a></li>
-            <li><a href="https://support.stnetradio.com" target="_blank">Support</a></li>
-          </ul>
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li><a href="/plus/">Plus+</a></li>
+                <li><a href="#">Podcast</a></li>
+                <li><a href="https://support.stnetradio.com" target="_blank">Support</a></li>
+            </ul>
         </nav>
-      </header>
+    </header>
 
-        <section class="featured-section">
-            <h2>Featured Podcasts</h2>
-            <div class="podcasts-grid" id="podcastList">
-            </div>
-        </section>
+    <section class="featured-section">
+        <h2>Featured Podcasts</h2>
+        <div class="podcasts-grid" id="podcastList">
+        </div>
+    </section>
 
-        <footer>
-            <p>The link will direct you to Apple Podcasts.</p>
-            <p>&copy; 2025 <span class="copyright">STNET Radio.</span> All Rights Reserved.</p>
-            <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > Privacy Policy</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">Terms of Service</a></link>
-          </footer>
+    <footer>
+        <p>The link will direct you to Apple Podcasts.</p>
+        <p>&copy; 2025 <span class="copyright">STNET Radio.</span> All Rights Reserved.</p>
+        <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link"> Privacy Policy</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">Terms of Service</a></p>
+    </footer>
 
-</head>
     <script src="/JavaScript/podcast/index.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Render podcast cards with correctly closed anchor tags
- Restructure podcast index HTML into a valid head/body layout and fix footer links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d99891a808330be95b938cd4b2e87