### PR TITLE
Fix malformed tags across site

### DIFF
--- a/404.html
+++ b/404.html
@@ -35,7 +35,7 @@
   
   <footer>
     <p>&copy; 2025 <span class="copyright">STNET Radio. </span> All Rights Reserved.</p>
-    <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > Privacy Policy</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">Terms of Service</a></link>
+    <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > Privacy Policy</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">Terms of Service</a></p>
   </footer>
-</body>
-</html>
+ </body>
+ </html>

--- a/JavaScript/podcast/index.js
+++ b/JavaScript/podcast/index.js
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     </div>
                     <div class="podcast-stats">
                         <span>★ ${podcast.rating}</span> 
-                        <span>|
+                        <span>|</span>
                         <span>${podcast.listeners} listeners</span>
                     </div>
                 </div>

--- a/JavaScript/podcast/tmsa.js
+++ b/JavaScript/podcast/tmsa.js
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     </div>
                     <div class="podcast-stats">
                         <span>★ ${podcast.rating}</span> 
-                        <span>|
+                        <span>|</span>
                         <span>${podcast.listeners} listeners</span>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
   
   <footer>
     <p>&copy; 2025 <span class="copyright">STNET Radio.</span> All Rights Reserved.</p>
-    <p class="st-link"><a href="/Privacy-Policy" class="st-link" > Privacy Policy</a> | <a href="/Terms-of-Service" class="st-link">Terms of Service</a></link>
-  </footer>
-</body>
-</html>
+      <p class="st-link"><a href="/Privacy-Policy" class="st-link" > Privacy Policy</a> | <a href="/Terms-of-Service" class="st-link">Terms of Service</a></p>
+    </footer>
+  </body>
+  </html>

--- a/plus/index.html
+++ b/plus/index.html
@@ -7,8 +7,7 @@
   <link rel="icon" href="https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/logo/fav.ico" type="image/x-icon">
   <link rel="stylesheet" href="/CSS/plus/plus.css">
   <link rel="stylesheet" href="/CSS/brand.css">
-  <link rel="stylesheet" href="/CSS/brand.css">
-  <link rel="stylesheet" href="/CSS/plus/footer.css"
+  <link rel="stylesheet" href="/CSS/plus/footer.css">
 </head>
 
 <body>
@@ -47,7 +46,8 @@
 
       <footer>
         <p>&copy; 2025 <span class="copyright">STNET Radio.</span> All Rights Reserved.</p>
-        <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > Privacy Policy</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">Terms of Service</a></link>
+        <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > Privacy Policy</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">Terms of Service</a></p>
       </footer>
 
-</body>
+  </body>
+  </html>

--- a/podcast/index.html
+++ b/podcast/index.html
@@ -2,13 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Podcast | STNET Radio</title>
-  <link rel="icon" href="https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/logo/fav.ico" type="image/x-icon">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Podcast | STNET Radio</title>
+    <link rel="icon" href="https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/logo/fav.ico" type="image/x-icon">
     <link rel="stylesheet" href="/CSS/podcast/index.css">
     <link rel="stylesheet" href="/CSS/footer.css">
     <link rel="stylesheet" href="/CSS/brand.css">
-
+</head>
+<body>
     <header>
         <a href="https://stnetradio.com" class="brand">STNET Radio</a>
         <nav>
@@ -30,10 +31,8 @@
         <footer>
             <p>The link will direct you to Apple Podcasts.</p>
             <p>&copy; 2025 <span class="copyright">STNET Radio.</span> All Rights Reserved.</p>
-            <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > Privacy Policy</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">Terms of Service</a></link>
-          </footer>
-
-</head>
-    <script src="/JavaScript/podcast/index.js"></script>
-</body>
-</html>
+            <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > Privacy Policy</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">Terms of Service</a></p>
+        </footer>
+        <script src="/JavaScript/podcast/index.js"></script>
+    </body>
+    </html>

--- a/th/index.html
+++ b/th/index.html
@@ -36,7 +36,7 @@
   
   <footer>
     <p>&copy; 2025 <span class="copyright">STNET Radio.</span> สงวนลิขสิทธิ์ทั้งหมด</p>
-    <p class="st-link"><a href="/Privacy-Policy" class="st-link" > นโยบายความเป็นส่วนตัว</a> | <a href="/Terms-of-Service" class="st-link">เงื่อนไขการให้บริการ</a></link>
+    <p class="st-link"><a href="/Privacy-Policy" class="st-link" > นโยบายความเป็นส่วนตัว</a> | <a href="/Terms-of-Service" class="st-link">เงื่อนไขการให้บริการ</a></p>
   </footer>
-</body>
-</html>
+  </body>
+  </html>

--- a/th/plus/index.html
+++ b/th/plus/index.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="https://s3.ap-southeast-1.amazonaws.com/files.stnetradio.com/logo/fav.ico" type="image/x-icon">
   <link rel="stylesheet" href="/CSS/th/plus/plus.css">
   <link rel="stylesheet" href="/CSS/th/brand.css">
-  <link rel="stylesheet" href="/CSS/th/footer.css"
+    <link rel="stylesheet" href="/CSS/th/footer.css">
 </head>
 
 <body>
@@ -46,7 +46,8 @@
 
       <footer>
         <p>&copy; 2025 <span class="copyright">STNET Radio.</span> สงวนลิขสิทธิ์ทั้งหมด</p>
-        <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > นโยบายความเป็นส่วนตัว</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">เงื่อนไขการให้บริการ</a></link>
+        <p class="st-link"><a href="https://docs.stnetradio.com/privacy-policy" class="st-link" > นโยบายความเป็นส่วนตัว</a> | <a href="https://docs.stnetradio.com/terms-of-service" class="st-link">เงื่อนไขการให้บริการ</a></p>
       </footer>
 
 </body>
+</html>


### PR DESCRIPTION
## Summary
- close missing span dividers in podcast scripts
- replace invalid footer `</link>` tags with `</p>` and restore valid HTML structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d99891a808330be95b938cd4b2e87