### PR TITLE
fix: correct podcast card HTML structure

### DIFF
--- a/JavaScript/podcast/index.js
+++ b/JavaScript/podcast/index.js
@@ -15,7 +15,6 @@ document.addEventListener("DOMContentLoaded", () => {
     function renderPodcasts() {
         podcastList.innerHTML = podcasts.map(podcast => `
             <a href="${podcast.link}" class="podcast-card">
-            <div class="podcast-card">
                 <div class="podcast-image">
                     <img src="${podcast.image}" alt="${podcast.title}">
                 </div>
@@ -27,12 +26,12 @@ document.addEventListener("DOMContentLoaded", () => {
                         by ${podcast.creator}
                     </div>
                     <div class="podcast-stats">
-                        <span>★ ${podcast.rating}</span> 
-                        <span>|
+                        <span>★ ${podcast.rating}</span>
+                        <span>|</span>
                         <span>${podcast.listeners} listeners</span>
                     </div>
                 </div>
-            </div>
+            </a>
         `).join('');
     }
 


### PR DESCRIPTION
## Summary
- ensure podcast card link wraps entire card and close anchor tag
- fix missing closing tag for separator span

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d99891a808330be95b938cd4b2e87